### PR TITLE
Add TestDataLogger, populate_test_data debug task, and VS Code launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,14 @@
       "program": "${workspaceFolder}/scripts/debug_tasks.py",
       "args": ["delta", "--db", "data/animeon.sqlite"],
       "console": "integratedTerminal"
+    },
+    {
+      "name": "Providers: Populate Test Data",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/scripts/debug_tasks.py",
+      "args": ["populate_test_data", "--query", "Example Anime"],
+      "console": "integratedTerminal"
     }
   ]
 }

--- a/stream2mediaserver/main_logic.py
+++ b/stream2mediaserver/main_logic.py
@@ -165,6 +165,9 @@ class MainLogic:
     def _enabled_providers(self) -> List[str]:
         return [name for name, enabled in self.config.providers.items() if enabled]
 
+    def enabled_provider_names(self) -> List[str]:
+        return self._enabled_providers()
+
     async def _search_providers(
         self, query: str, provider_names: Iterable[str]
     ) -> List[SearchResult]:

--- a/stream2mediaserver/processors/request_manager.py
+++ b/stream2mediaserver/processors/request_manager.py
@@ -6,6 +6,7 @@ import requests
 
 from ..config import config
 from ..utils.logger import logger
+from ..utils.test_data_logger import TestDataLogger
 
 
 class RequestManager:
@@ -45,8 +46,10 @@ class RequestManager:
                 timeout=cls.DEFAULT_TIMEOUT,
             )
             response.raise_for_status()
+            TestDataLogger.log_response(response)
             return response
         except requests.RequestException as e:
+            TestDataLogger.log_response(getattr(e, "response", None), error=str(e))
             logger.error(f"GET request failed for {url}: {str(e)}")
             return None
 
@@ -73,7 +76,9 @@ class RequestManager:
                 timeout=cls.DEFAULT_TIMEOUT,
             )
             response.raise_for_status()
+            TestDataLogger.log_response(response)
             return response
         except requests.RequestException as e:
+            TestDataLogger.log_response(getattr(e, "response", None), error=str(e))
             logger.error(f"POST request failed for {url}: {str(e)}")
             return None

--- a/stream2mediaserver/utils/test_data_logger.py
+++ b/stream2mediaserver/utils/test_data_logger.py
@@ -1,0 +1,96 @@
+"""Utilities for dumping provider response data."""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator, Optional
+
+import requests
+
+
+_provider_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "test_data_provider", default="unknown"
+)
+_test_case_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "test_data_case", default="unspecified"
+)
+_action_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "test_data_action", default="response"
+)
+
+
+class TestDataLogger:
+    """Tracks and writes HTTP responses for debug runs."""
+
+    enabled = False
+    base_dir = Path("data/test_data")
+
+    @classmethod
+    def configure(cls, base_dir: Optional[Path] = None, enabled: bool = True) -> None:
+        if base_dir is not None:
+            cls.base_dir = base_dir
+        cls.enabled = enabled
+
+    @classmethod
+    @contextlib.contextmanager
+    def context(cls, provider: str, test_case: str, action: str) -> Iterator[None]:
+        provider_token = _provider_var.set(cls._sanitize(provider))
+        test_case_token = _test_case_var.set(cls._sanitize(test_case))
+        action_token = _action_var.set(cls._sanitize(action))
+        try:
+            yield
+        finally:
+            _provider_var.reset(provider_token)
+            _test_case_var.reset(test_case_token)
+            _action_var.reset(action_token)
+
+    @classmethod
+    def log_response(
+        cls, response: Optional[requests.Response], error: Optional[str] = None
+    ) -> None:
+        if not cls.enabled or response is None:
+            return
+        cls.base_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(timezone.utc).strftime("%d%m%Y%H%M%S")
+        provider = _provider_var.get()
+        test_case = _test_case_var.get()
+        action = _action_var.get()
+        extension = cls._extension_for_response(response)
+        filename = f"{provider}_{test_case}_{action}.{timestamp}.{extension}"
+        target_path = cls.base_dir / filename
+        try:
+            target_path.write_bytes(response.content or b"")
+        except OSError:
+            return
+        meta_path = target_path.with_suffix(f"{target_path.suffix}.meta.json")
+        metadata = {
+            "url": response.url,
+            "status_code": response.status_code,
+            "headers": dict(response.headers),
+            "error": error,
+        }
+        try:
+            meta_path.write_text(json.dumps(metadata, ensure_ascii=False, indent=2))
+        except OSError:
+            return
+
+    @staticmethod
+    def _extension_for_response(response: requests.Response) -> str:
+        content_type = response.headers.get("Content-Type", "")
+        if "json" in content_type:
+            return "json"
+        if "html" in content_type:
+            return "html"
+        if "xml" in content_type:
+            return "xml"
+        return "txt"
+
+    @staticmethod
+    def _sanitize(value: str) -> str:
+        cleaned = "".join(char if char.isalnum() else "_" for char in value)
+        cleaned = cleaned.strip("_").lower()
+        return cleaned or "unknown"


### PR DESCRIPTION
### Motivation
- Provide a way to capture real provider HTTP responses for debugging and to support creating stable test fixtures. 
- Expose an easy CLI workflow to populate test data from enabled providers. 
- Make the new debug flow easy to run from an IDE using a launch configuration.

### Description
- Add `stream2mediaserver/utils/test_data_logger.py` implementing `TestDataLogger` to capture responses and write content plus a `.meta.json` sidecar with `url`, `status_code`, `headers`, and optional `error` into a configurable `base_dir`.
- Wire `TestDataLogger.log_response` into `RequestManager.get` and `RequestManager.post` so successful responses and request exceptions are recorded when logging is enabled, and add `MainLogic.enabled_provider_names()` as a small helper.
- Extend `scripts/debug_tasks.py` with `run_populate_test_data` and a `populate_test_data` CLI action plus a `--dump-dir` option that enables `TestDataLogger` and iterates enabled providers to capture search and details outputs.
- Add a VS Code launch configuration at `.vscode/launch.json` to run the `populate_test_data` action from the IDE.

### Testing
- Ran `ruff check .` which completed with all checks passed. 
- Ran `ruff format .` which left files unchanged. 
- Ran the full test suite with `pytest` resulting in `13 passed, 2 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697efa842b5083289124deb11751a8c1)